### PR TITLE
derive LuaException from std::runtime_error

### DIFF
--- a/src/include/impl/LuaException.h
+++ b/src/include/impl/LuaException.h
@@ -24,7 +24,7 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-class LuaException : public std::exception
+class LuaException : public std::runtime_error
 {
 public:
     explicit LuaException(lua_State* L) noexcept


### PR DESCRIPTION
When using LuaIntf this allows for a better exception handling by not catching any exception in code, only the runtime errors.