### PR TITLE
LuaType: return default value when bool is nil

### DIFF
--- a/src/include/impl/LuaType.h
+++ b/src/include/impl/LuaType.h
@@ -88,7 +88,7 @@ struct LuaTypeMapping <bool>
 
     static bool opt(lua_State* L, int index, bool def)
     {
-        return lua_isnone(L, index) ? def : lua_toboolean(L, index) != 0;
+        return lua_isnoneornil(L, index) ? def : lua_toboolean(L, index) != 0;
     }
 };
 


### PR DESCRIPTION
Calls to `tbl.get<bool>("foo", true)` would return false if `foo` is `nil`. This will return the default (`true`) instead.